### PR TITLE
Pass a PostRenderer down to helm

### DIFF
--- a/client.go
+++ b/client.go
@@ -248,6 +248,10 @@ func (c *HelmClient) install(ctx context.Context, spec *ChartSpec) (*release.Rel
 		client.Version = ">0.0.0-0"
 	}
 
+	if spec.PostRenderer != nil {
+		client.PostRenderer = spec.PostRenderer
+	}
+
 	helmChart, chartPath, err := c.getChart(spec.ChartName, &client.ChartPathOptions)
 	if err != nil {
 		return nil, err
@@ -311,6 +315,10 @@ func (c *HelmClient) upgrade(ctx context.Context, spec *ChartSpec) (*release.Rel
 
 	if client.Version == "" {
 		client.Version = ">0.0.0-0"
+	}
+
+	if spec.PostRenderer != nil {
+		client.PostRenderer = spec.PostRenderer
 	}
 
 	helmChart, chartPath, err := c.getChart(spec.ChartName, &client.ChartPathOptions)

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/postrender"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -130,4 +131,7 @@ type ChartSpec struct {
 	// DryRun indicates whether to perform a dry run.
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
+	// PostRenderer to run on the Helm Chart
+	// +optional
+	PostRenderer postrender.PostRenderer `json:"postRenderer,omitempty"`
 }


### PR DESCRIPTION
This is to allow the use of this https://helm.sh/docs/topics/advanced/

We need it because we want to add labels to everything to make connecting which chart deployed what possible.